### PR TITLE
x-variable ordering options and better breakpoint determination logic

### DIFF
--- a/R/averages.R
+++ b/R/averages.R
@@ -204,13 +204,20 @@ avg_exercise_test.time <- function(.data,
 
         out <- data_num %>%
             dplyr::mutate(
-                dplyr::across(tidyselect::everything(), ~
-                                  slide_index_dbl(., .i = time,
-                                                  .f = mos, na.rm = TRUE,
-                                                  trim = roll_trim / roll_window / 2,
-                                                  .before = b, .after = a,
-                                                  .complete = TRUE))) %>%
-            dplyr::filter(dplyr::if_any(tidyselect::everything(), ~ !is.na(.)))
+                dplyr::across(
+                    tidyselect::everything(),
+                    ~ slider::slide_index_dbl(
+                            .,
+                            .i = time,
+                            .f = mos,
+                            na.rm = TRUE,
+                            trim = roll_trim / roll_window / 2,
+                            .before = b,
+                            .after = a,
+                            .complete = FALSE
+                        ))) %>%
+            dplyr::filter(dplyr::if_any(tidyselect::everything(),
+                                        ~ !is.na(.)))
 
         return(out)
 
@@ -283,13 +290,13 @@ avg_exercise_test.digital <- function(.data,
 
     bf <- butter_lowpass(cutoff = cutoff, fs = fs, order = order)
 
+    # should this exclude the time column?
     out <- purrr::map(.x = data_num,
                       .f = function(.x, bf) signal::filter(bf, .x),
                       bf = bf)
 
     out <- dplyr::bind_cols(char_cols, out)
     return(out)
-
 }
 
 #' @keywords internal

--- a/R/breakpoint.R
+++ b/R/breakpoint.R
@@ -31,6 +31,7 @@
 #' @param ordering Prior to fitting any functions, should the data be reordered by the x-axis variable or by time? Default is to use the current x-axis variable and use the time variable to break any ties.
 #' @param pos_change_vt1 Do you expect the change in slope to be positive (default) or negative? If a two-line regression significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate.
 #' @param pos_change_vt2 Do you expect the change in slope to be positive (default) or negative? If a two-line regression significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate. *The only time you should set this to `FALSE` is when your y-axis variable is end-tidal carbon dioxide (PetCO2)*.
+#' @param pos_slope_after_bp Should the slope after the breakpoint be positive? Default is `TRUE`. This catches cases when the percent change in slope is positive, but the second slope is still negative. Change to `FALSE` when PetCO2 is the y-axis variable.
 #'
 #' @returns A list that contains a data frame with slices of the original data frame at the threshold index. The data frame new columns describing the methods used and if the breakpoint was truly a breakpoint. Depending on the breakpoint algorithm used, `breakpoint()` also returns fitted values, the left and right sides of the piecewise regression, as well as a simple linear regression.
 #' @export
@@ -71,6 +72,7 @@ breakpoint <- function(.data,
                        truncate = TRUE, # may be unnecessary for deriv algs
                        pos_change_vt1 = TRUE,
                        pos_change_vt2 = TRUE,
+                       pos_slope_after_bp = TRUE,
                        ordering = c("by_x", "time"),
                        ...) {
 

--- a/R/piecewise_helpers.R
+++ b/R/piecewise_helpers.R
@@ -57,3 +57,20 @@ make_piecewise_bp_plot <- function(.data, .x, .y, lm_left, lm_right,
         ggplot2::theme_minimal()
     bp_plot
 }
+
+#' Check if the breakpoint is a "true" breakpoint
+#'
+#' There must be a better fit than a single regression line p < alpha the slope must change in the direction indicated (usually positive) the direction of the second slope must match the expected direction  (we usually expect the second slope to be positive). This is necessary because you can have a positive percent change but still have a negative second slope.
+#' @keywords internal
+#' @noRd
+#'
+check_if_determinant_bp <- function(p, pct_slope_change,
+                                    pos_change, pos_slope_after_bp,
+                                    slope_after_bp, alpha = 0.05) {
+
+    determinant_bp <- dplyr::if_else(all(p < alpha,
+                                         pos_change == (pct_slope_change > 0),
+                                         pos_slope_after_bp == (slope_after_bp > 0)),
+                                     TRUE, FALSE)
+    determinant_bp
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -83,3 +83,18 @@ set_front_trim <- function(bp, front_trim_vt1, front_trim_vt2) {
     front_trim
 }
 
+#' Order data by x-variable and time, or by exclusively the time variable
+#'
+#' @keywords internal
+#' @noRd
+order_cpet_df <- function(.data, .x, time, ordering = c("by_x", "time")) {
+    ordering <- match.arg(ordering, several.ok = FALSE)
+    if(ordering == "by_x") {
+        .data <- .data %>%
+            dplyr::arrange(get(.x), time)
+    } else {
+        .data <- .data %>%
+            dplyr::arrange(time)
+    }
+    .data
+}

--- a/R/wb_rc.R
+++ b/R/wb_rc.R
@@ -38,6 +38,7 @@ wb_rc <- function(.data,
                   .x,
                   .y,
                   bp,
+                  ...,
                   vo2 = "vo2",
                   vco2 = "vco2",
                   ve = "ve",
@@ -46,8 +47,8 @@ wb_rc <- function(.data,
                   front_trim_vt1 = 60,
                   front_trim_vt2 = 60,
                   pos_change = TRUE,
-                  min_pct_change = 0.15,
-                  ...) {
+                  min_pct_change = 0.15
+                  ) {
 
     stopifnot(!any(missing(.data), missing(.x), missing(.y), missing(bp)))
     bp = match.arg(bp, choices = c("vt1", "vt2"), several.ok = FALSE)
@@ -55,8 +56,10 @@ wb_rc <- function(.data,
         warning("The `x` variable may NOT be VCO2 or y variable may NOT be VE. This method is designed to work with x = VO2 and y = VE")
     }
 
-    .data <- .data %>% # rearrange by x variable. Use time var to break ties.
-        dplyr::arrange(.data[[.x]], .data[[time]])
+    ordering <- match.arg(ordering, several.ok = FALSE)
+
+    .data <- order_cpet_df(.data, .x = .x , time = time,
+                           ordering = ordering)
     plot_df <- .data # save full data frame for plotting later
 
     front_trim <- set_front_trim(bp = bp,

--- a/code_testing/thresholds/breakpoint_testing.R
+++ b/code_testing/thresholds/breakpoint_testing.R
@@ -2,41 +2,48 @@ library(gasExchangeR)
 library(devtools)
 library(tidyverse)
 library(janitor)
+library(readxl)
 
-file_lines <- readLines("inst/extdata/Anton_vo2max.txt")
-df_raw <- read.table(textConnection(file_lines[-2]), header = TRUE, sep="\t")
+df_unavg <- read_xlsx("../gasExchangeR_validation/data/processed/rand_15_cpet_exercisethresholds/mar22_196_post_retest_gxt.xlsx") %>%
+    rename(vo2 = vo2_abs,
+           vo2_kg = vo2)
 
-df_unavg <- df_raw %>%
-    as_tibble() %>%
-    clean_names() %>%
-    separate(`time`, into = c("m1", "s1"), sep = ":") %>%
-    separate(ex_time, into = c("m2", "s2"), sep = ":") %>%
-    separate(time_clock,
-             into = c("h3", "m3", "s3"),
-             sep = ":") %>%
-    mutate(across(where(is.character), as.numeric)) %>%
-    mutate(time = (m1*60 + s1), .keep = "unused") %>%
-    mutate(ex_time = (m2*60 + s2 ), .keep = "unused") %>%
-    mutate(clock_time = hms::hms(s3, m3, h3), .keep = "unused") %>%
-    relocate(contains("time")) %>%
-    filter(!is.na(ex_time)) %>%
-    filter(speed >= 4.5 & ex_time >= 750) %>%
-    select(-time) %>%
-    rename(time = ex_time,
-           vo2_kg = vo2,
-           vo2 = vo2_1,
-           ve = ve_btps) %>%
-    mutate(ve_vo2 = ve / vo2 * 1000,
-           ve_vco2 = ve/vco2*1000,
-           excess_co2 = vco2^2 / vo2 - vco2) %>%
-    ventilatory_outliers(plot_outliers = FALSE)
+# file_lines <- readLines("inst/extdata/Anton_vo2max.txt")
+# df_raw <- read.table(textConnection(file_lines[-2]), header = TRUE, sep="\t")
+#
+# df_unavg <- df_raw %>%
+#     as_tibble() %>%
+#     clean_names() %>%
+#     separate(`time`, into = c("m1", "s1"), sep = ":") %>%
+#     separate(ex_time, into = c("m2", "s2"), sep = ":") %>%
+#     separate(time_clock,
+#              into = c("h3", "m3", "s3"),
+#              sep = ":") %>%
+#     mutate(across(where(is.character), as.numeric)) %>%
+#     mutate(time = (m1*60 + s1), .keep = "unused") %>%
+#     mutate(ex_time = (m2*60 + s2 ), .keep = "unused") %>%
+#     mutate(clock_time = hms::hms(s3, m3, h3), .keep = "unused") %>%
+#     relocate(contains("time")) %>%
+#     filter(!is.na(ex_time)) %>%
+#     filter(speed >= 4.5 & ex_time >= 750) %>%
+#     select(-time) %>%
+#     rename(time = ex_time,
+#            vo2_kg = vo2,
+#            vo2 = vo2_1,
+#            ve = ve_btps) %>%
+#     mutate(ve_vo2 = ve / vo2 * 1000,
+#            ve_vco2 = ve/vco2*1000,
+#            excess_co2 = vco2^2 / vo2 - vco2) %>%
+#     ventilatory_outliers(plot_outliers = FALSE)
 
-df_avg <- avg_exercise_test(df_unavg, type = "breath", subtype = "rolling",
-                            time_col = "time", roll_window = 15)
+df_avg <- avg_exercise_test(df_unavg, type = "time", subtype = "bin",
+                            time_col = "time", bin_w = 15)
 
 ggplot(data = df_avg, aes(x = time)) +
     geom_point(aes(y = vo2), color = "red", alpha = 0.5) +
+    geom_line(aes(y = vo2), color = "red", alpha = 0.5) +
     geom_point(aes(y = vco2), color = "blue", alpha = 0.5) +
+    geom_line(aes(y = vco2), color = "blue", alpha = 0.5) +
     theme_minimal()
 
 ggplot(data = df_avg, aes(x = vo2, y = vco2)) +
@@ -57,55 +64,94 @@ ggplot(data = df_avg, aes(x = time)) +
     ggtitle("Ventilatory Equivalents") +
     theme_minimal()
 
-vt1_only_algs <- c("v-slope", "d1_crossing", )
+# vt1_only_algs <- c("v-slope", "d1_crossing")
 
-algorithms <- c("jm", "orr", "dmax", "spline_bp",
-                "d2_inflection", "d1_poly_reg_maxima",
-                "d2_reg_spline_maxima")
+# algorithms <- c("jm", "orr", "dmax", "spline_bp",
+#                 "d2_inflection", "d1_poly_reg_maxima",
+#                 "d2_reg_spline_maxima")
+debug(d2_reg_spline_maxima)
+
+breakpoint(df_avg,
+           algorithm_vt1 = "v-slope",
+           x_vt1 = "vo2",
+           y_vt1 = "vco2",
+           algorithm_vt2 = "d2_reg_spline_maxima",
+           x_vt2 = "vco2",
+           y_vt2 = "ve",
+           bp = "both",
+           truncate = TRUE
+)
+
+undebug(d2_reg_spline_maxima)
+
 
 bp_dat <- breakpoint(.data = df_avg, method = "excess_co2",
+                     x_vt1 = "vo2",
                      algorithm_vt1 = "spline_bp",
                      algorithm_vt2 = "d2_poly_reg_maxima",
                      x_vt2 = "vo2", y_vt2 = "ve_vco2", truncate = TRUE,
                      front_trim_vt1 = 90)
+bp_dat$vt1_dat$bp_plot
+bp_dat$vt2_dat$bp_plot
 
-bp_dat <- breakpoint(.data = df_avg, method = "excess_co2",
-                     algorithm_vt1 = "spline_bp",
-                     algorithm_vt2 = "d2_poly_reg_maxima",
-                     x_vt2 = "vo2", y_vt2 = "ve_vco2", truncate = TRUE,
-                     front_trim_vt1 = 90)
-
-bp_dat <- breakpoint(.data = df_avg, x_vt1 = "time", y_vt1 = "vo2",
+bp_dat <- breakpoint(.data = df_avg,
                      algorithm_vt1 = "d1_crossing",
-                     algorithm_vt2 = "d2_poly_reg_maxima",
-                     x_vt2 = "vo2", y_vt2 = "ve_vco2", truncate = FALSE,
-                     front_trim_vt1 = 0)
+                     x_vt1 = "time", y_vt1 = "vo2",
+                     algorithm_vt2 = "d2_reg_spline_maxima",
+                     x_vt2 = "vo2", y_vt2 = "ve_vco2",
+                     bp = "both", truncate = FALSE)
+bp_dat$vt1_dat$bp_plot
+bp_dat$vt2_dat$bp_plot
+
+debug(d2_reg_spline_maxima)
+bp_dat <- breakpoint(.data = df_avg, x_vt1 = "vo2", y_vt1 = "vco2",
+                     algorithm_vt1 = "d2_reg_spline_maxima",
+                     algorithm_vt2 = "d2_reg_spline_maxima",
+                     x_vt2 = "vco2", y_vt2 = "ve",
+                     pos_change_vt2 = TRUE, truncate = TRUE)
+bp_dat$vt1_dat$bp_plot
+bp_dat$vt2_dat$bp_plot
 
 bp_dat <- breakpoint(.data = df_avg, x_vt1 = "vo2", y_vt1 = "ve",
                      algorithm_vt1 = "d2_inflection",
                      algorithm_vt2 = "d2_inflection",
-                     x_vt2 = "vco2", y_vt2 = "ve", truncate = TRUE,
-                     front_trim_vt1 = 0)
+                     x_vt2 = "vco2", y_vt2 = "ve", truncate = TRUE)
+bp_dat$vt1_dat$bp_plot
+bp_dat$vt2_dat$bp_plot
 
 bp_dat <- breakpoint(.data = df_avg, x_vt1 = "vo2", y_vt1 = "vco2",
                      algorithm_vt1 = "dmax",
                      algorithm_vt2 = "dmax",
-                     x_vt2 = "vco2", y_vt2 = "ve", truncate = TRUE)
-
+                     x_vt2 = "vco2", y_vt2 = "ve", truncate = TRUE,
+                     ordering = "time")
+bp_dat$vt1_dat$bp_plot
+bp_dat$vt2_dat$bp_plot
+# debug(check_if_determinant_bp)
 bp_dat <- breakpoint(.data = df_avg, x_vt1 = "vo2", y_vt1 = "vco2",
-                     algorithm_vt1 = "jm",
-                     algorithm_vt2 = "jm",
-                     x_vt2 = "vco2", y_vt2 = "ve", truncate = TRUE)
+                     algorithm_vt1 = "v-slope",
+                     algorithm_vt2 = "spline_bp",
+                     x_vt2 = "vco2", y_vt2 = "ve", truncate = TRUE,
+                     ordering = "time")
+bp_dat$bp_dat
+bp_dat$vt1_dat$bp_plot
+bp_dat$vt2_dat$bp_plot
 
 bp_dat <- breakpoint(.data = df_avg, x_vt1 = "vo2", y_vt1 = "vco2",
                      algorithm_vt1 = "v-slope",
                      algorithm_vt2 = "d2_reg_spline_maxima",
-                     x_vt2 = "vo2", y_vt2 = "ve_vco2", truncate = TRUE)
-
+                     x_vt2 = "vo2", y_vt2 = "ve_vco2", truncate = TRUE,
+                     ordering = "time")
+bp_dat$vt1_dat$bp_plot
+bp_dat$vt2_dat$bp_plot
+debug(orr)
+# undebug(orr)
 bp_dat <- breakpoint(.data = df_avg, x_vt1 = "vo2", y_vt1 = "vco2",
                      algorithm_vt1 = "orr",
                      algorithm_vt2 = "orr",
-                     x_vt2 = "vco2", y_vt2 = "ve", truncate = TRUE)
+                     x_vt2 = "vco2", y_vt2 = "ve", truncate = TRUE,
+                     ordering = "time")
+bp_dat$vt1_dat$bp_plot
+bp_dat$vt2_dat$bp_plot
 
 print(bp_dat$bp_dat, width = Inf)
 

--- a/code_testing/thresholds/breakpoint_testing.R
+++ b/code_testing/thresholds/breakpoint_testing.R
@@ -69,7 +69,7 @@ ggplot(data = df_avg, aes(x = time)) +
 # algorithms <- c("jm", "orr", "dmax", "spline_bp",
 #                 "d2_inflection", "d1_poly_reg_maxima",
 #                 "d2_reg_spline_maxima")
-debug(d2_reg_spline_maxima)
+debug(breakpoint)
 
 breakpoint(df_avg,
            algorithm_vt1 = "v-slope",
@@ -79,7 +79,8 @@ breakpoint(df_avg,
            x_vt2 = "vco2",
            y_vt2 = "ve",
            bp = "both",
-           truncate = TRUE
+           truncate = TRUE,
+           pos_slope_after_bp = FALSE,
 )
 
 undebug(d2_reg_spline_maxima)

--- a/code_testing/thresholds/piecewise/jm_testing.R
+++ b/code_testing/thresholds/piecewise/jm_testing.R
@@ -22,18 +22,18 @@ df_unavg <- df_raw %>%
     ventilatory_outliers(outlier_cols = "vo2_abs", plot_outliers = FALSE)
 
 df_avg <- avg_exercise_test(df_unavg,
-                            type = "breath",
-                            subtype = "rolling",
-                            roll_window = 15,
+                            type = "time",
+                            subtype = "bin",
+                            bin_w = 10,
                             time_col = "time")
 
 ggplot(data = df_unavg, aes(x = vco2, y = ve)) +
     geom_point() +
-    geom_point(data = df_avg, aes(x = vco2, y = ve), color = "red")
+    geom_point(data = df_avg, aes(x = vco2, y = ve), color = "orange")
 
 ggplot(data = df_unavg, aes(x = as.numeric(time), y = ve)) +
     geom_point() +
-    geom_point(data = df_avg, aes(x = time, y = ve), color = "red")
+    geom_point(data = df_avg, aes(x = time, y = ve), color = "orange")
 
 ggplot(data = df_unavg, aes(x = as.numeric(time), y = vo2_abs)) +
     geom_point() +
@@ -62,7 +62,8 @@ use_browser <- function(func, ...) {
 }
 use_browser("jm", .data = df_avg, .x = "vco2", .y = "ve", vo2 = "vo2_abs", bp = "vt2")
 
-bp_dat <- jm(.data = df_avg, x_vt2, y_vt2, vo2 = "vo2_abs", bp = "vt2")
+bp_dat <- jm(.data = df_avg, .x = "vco2", .y = "ve",
+             vo2 = "vo2_abs", bp = "vt2")
 bp_dat$gp
 
 bp_dat$breakpoint_data %>% View

--- a/code_testing/thresholds/piecewise/orr_testing.R
+++ b/code_testing/thresholds/piecewise/orr_testing.R
@@ -22,6 +22,10 @@ df_unavg <- df_raw %>%
 df_avg <- avg_exercise_test(df_unavg, type = "time", subtype = "bin",
                             time_col = "time", bin_w = 10)
 
+ggplot(data = df_avg, aes(x = time, y = vo2)) +
+    geom_point(alpha = 0.5) +
+    theme_bw()
+
 breakpoint(.data = df_avg,
            x_vt1 = "vo2",
            y_vt1 = "vco2",

--- a/man/breakpoint.Rd
+++ b/man/breakpoint.Rd
@@ -24,6 +24,7 @@ breakpoint(
   truncate = TRUE,
   pos_change_vt1 = TRUE,
   pos_change_vt2 = TRUE,
+  pos_slope_after_bp = TRUE,
   ordering = c("by_x", "time"),
   ...
 )
@@ -66,6 +67,8 @@ breakpoint(
 \item{pos_change_vt1}{Do you expect the change in slope to be positive (default) or negative? If a two-line regression significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate.}
 
 \item{pos_change_vt2}{Do you expect the change in slope to be positive (default) or negative? If a two-line regression significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate. \emph{The only time you should set this to \code{FALSE} is when your y-axis variable is end-tidal carbon dioxide (PetCO2)}.}
+
+\item{pos_slope_after_bp}{Should the slope after the breakpoint be positive? Default is \code{TRUE}. This catches cases when the percent change in slope is positive, but the second slope is still negative. Change to \code{FALSE} when PetCO2 is the y-axis variable.}
 
 \item{ordering}{Prior to fitting any functions, should the data be reordered by the x-axis variable or by time? Default is to use the current x-axis variable and use the time variable to break any ties.}
 

--- a/man/breakpoint.Rd
+++ b/man/breakpoint.Rd
@@ -22,7 +22,9 @@ breakpoint(
   front_trim_vt2 = NULL,
   alpha_linearity = 0.05,
   truncate = TRUE,
-  pos_change = TRUE,
+  pos_change_vt1 = TRUE,
+  pos_change_vt2 = TRUE,
+  ordering = c("by_x", "time"),
   ...
 )
 }
@@ -61,7 +63,11 @@ breakpoint(
 
 \item{truncate}{By default, this function truncates the data frame at VT2 prior to finding VT1. Change truncate to \code{FALSE} to use the entire data frame when searching for VT1.}
 
-\item{pos_change}{Do you expect the change in slope to be positive (default) or negative? If a two-line regression significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate.}
+\item{pos_change_vt1}{Do you expect the change in slope to be positive (default) or negative? If a two-line regression significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate.}
+
+\item{pos_change_vt2}{Do you expect the change in slope to be positive (default) or negative? If a two-line regression significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate. \emph{The only time you should set this to \code{FALSE} is when your y-axis variable is end-tidal carbon dioxide (PetCO2)}.}
+
+\item{ordering}{Prior to fitting any functions, should the data be reordered by the x-axis variable or by time? Default is to use the current x-axis variable and use the time variable to break any ties.}
 
 \item{...}{Arguments to pass to functions internal to \code{breakpoint()}}
 }

--- a/man/d1_crossing.Rd
+++ b/man/d1_crossing.Rd
@@ -8,6 +8,8 @@ d1_crossing(
   .data,
   .x,
   .y,
+  bp = "vt1",
+  ...,
   degree = NULL,
   vo2 = "vo2",
   vco2 = "vco2",
@@ -15,8 +17,7 @@ d1_crossing(
   time = "time",
   alpha_linearity = 0.05,
   pos_change = TRUE,
-  bp = "vt1",
-  ...
+  ordering = c("by_x", "time")
 )
 }
 \arguments{
@@ -25,6 +26,10 @@ d1_crossing(
 \item{.x}{The x-axis variable.}
 
 \item{.y}{the y-axis variable.}
+
+\item{bp}{Is this the first (\code{vt1}) or the second (\code{vt2}) breakpoint? This method is specifically designed for finding VT1 (GET)}
+
+\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
 
 \item{degree}{The polynomial degree the function should fit to the curve. If left \code{NULL} this function finds the best fit.}
 
@@ -39,10 +44,6 @@ d1_crossing(
 \item{alpha_linearity}{Significance value to determine if a piecewise model explains significantly reduces the residual sums of squares more than a simpler model.}
 
 \item{pos_change}{Do you expect the change in slope to be positive (default) or negative? If a two-line regression explains significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate.}
-
-\item{bp}{Is this the first (\code{vt1}) or the second (\code{vt2}) breakpoint? This method is specifically designed for finding VT1 (GET)}
-
-\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
 }
 \value{
 A list include breakpoint data, best-fit and related functions, and a plot.

--- a/man/d2_inflection.Rd
+++ b/man/d2_inflection.Rd
@@ -9,13 +9,14 @@ d2_inflection(
   .x,
   .y,
   bp,
-  degree = 5,
+  ...,
+  degree = NULL,
   vo2 = "vo2",
   vco2 = "vco2",
   ve = "ve",
   time = "time",
   alpha_linearity = 0.05,
-  ...
+  ordering = c("by_x", "time")
 )
 }
 \arguments{
@@ -26,6 +27,8 @@ d2_inflection(
 \item{.y}{the y-axis variable.}
 
 \item{bp}{Is this the first (\code{vt1}) or the second (\code{vt2}) breakpoint?}
+
+\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
 
 \item{degree}{The polynomial degree the function should fit to the curve. If left \code{NULL} this function finds the best fit.}
 
@@ -39,7 +42,7 @@ d2_inflection(
 
 \item{alpha_linearity}{Significance value to determine if a piecewise model explains significantly reduces the residual sums of squares more than a simpler model.}
 
-\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
+\item{ordering}{Prior to fitting any functions, should the data be reordered by the x-axis variable or by time? Default is to use the current x-axis variable and use the time variable to break any ties.}
 }
 \value{
 A list containing breakpoint data, best-fit and related functions, and a plot.

--- a/man/d2_poly_reg_maxima.Rd
+++ b/man/d2_poly_reg_maxima.Rd
@@ -15,6 +15,8 @@ d2_poly_reg_maxima(
   ve = "ve",
   time = "time",
   alpha_linearity = 0.05,
+  pos_change = TRUE,
+  ordering = c("by_x", "time"),
   ...
 )
 }
@@ -38,6 +40,10 @@ d2_poly_reg_maxima(
 \item{time}{Name of the \code{time} variable}
 
 \item{alpha_linearity}{Significance value to determine if a piecewise model explains significantly reduces the residual sums of squares more than a simpler model.}
+
+\item{pos_change}{Do you expect the slope to be increasing at the breakpoint? This helps with filtering maxima.}
+
+\item{ordering}{Prior to fitting any functions, should the data be reordered by the x-axis variable or by time? Default is to use the current x-axis variable and use the time variable to break any ties.}
 
 \item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
 }

--- a/man/d2_reg_spline_maxima.Rd
+++ b/man/d2_reg_spline_maxima.Rd
@@ -9,6 +9,7 @@ d2_reg_spline_maxima(
   .x,
   .y,
   bp,
+  ...,
   degree = 5,
   df = NULL,
   vo2 = "vo2",
@@ -17,7 +18,7 @@ d2_reg_spline_maxima(
   time = "time",
   alpha_linearity = 0.05,
   pos_change = TRUE,
-  ...
+  ordering = c("by_x", "time")
 )
 }
 \arguments{
@@ -28,6 +29,13 @@ d2_reg_spline_maxima(
 \item{.y}{the y-axis variable.}
 
 \item{bp}{Is this the first (\code{vt1}) or the second (\code{vt2}) breakpoint?}
+
+\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.
+
+#' @references
+Leo, J. A., Sabapathy, S., Simmonds, M. J., & Cross, T. J. (2017). The Respiratory Compensation Point is Not a Valid Surrogate for Critical Power. Medicine and science in sports and exercise, 49(7), 1452-1460.
+Sherrill, D. L., Anderson, S. J., & Swanson, G. E. O. R. G. E. (1990). Using smoothing splines for detecting ventilatory thresholds. Medicine and Science in Sports and Exercise, 22(5), 684-689.
+Wade, T. D., Anderson, S. J., Bondy, J., Ramadevi, V. A., Jones, R. H., & Swanson, G. D. (1988). Using smoothing splines to make inferences about the shape of gas-exchange curves. Computers and biomedical research, 21(1), 16-26.}
 
 \item{degree}{The polynomial degree the function should fit to the curve. Most previous studies using this method use 3 or 5.}
 
@@ -45,12 +53,7 @@ d2_reg_spline_maxima(
 
 \item{pos_change}{Do you expect the slope to be increasing at the breakpoint? This helps with filtering maxima.}
 
-\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.
-
-#' @references
-Leo, J. A., Sabapathy, S., Simmonds, M. J., & Cross, T. J. (2017). The Respiratory Compensation Point is Not a Valid Surrogate for Critical Power. Medicine and science in sports and exercise, 49(7), 1452-1460.
-Sherrill, D. L., Anderson, S. J., & Swanson, G. E. O. R. G. E. (1990). Using smoothing splines for detecting ventilatory thresholds. Medicine and Science in Sports and Exercise, 22(5), 684-689.
-Wade, T. D., Anderson, S. J., Bondy, J., Ramadevi, V. A., Jones, R. H., & Swanson, G. D. (1988). Using smoothing splines to make inferences about the shape of gas-exchange curves. Computers and biomedical research, 21(1), 16-26.}
+\item{ordering}{}
 }
 \value{
 A slice of the original data frame at the threshold index with a new `algorithm` column.

--- a/man/dmax.Rd
+++ b/man/dmax.Rd
@@ -8,14 +8,16 @@ dmax(
   .data,
   .x,
   .y,
+  bp,
+  ...,
   vo2 = "vo2",
   vco2 = "vco2",
   ve = "ve",
   time = "time",
+  ordering = c("by_x", "time"),
   alpha_linearity = 0.05,
-  bp,
   pos_change = TRUE,
-  ...
+  pos_slope_after_bp = TRUE
 )
 }
 \arguments{
@@ -25,6 +27,10 @@ dmax(
 
 \item{.y}{the y-axis variable.}
 
+\item{bp}{Is this algorithm being used to find vt1 or vt2?}
+
+\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
+
 \item{vo2}{The name of the vo2 column in \code{.data}}
 
 \item{vco2}{The name of the vco2 column in \code{.data}}
@@ -33,13 +39,13 @@ dmax(
 
 \item{time}{The name of the time column in \code{.data}}
 
-\item{alpha_linearity}{Significance value to determine if a piecewise model explains significantly reduces the residual sums of squares more than a simpler model.}
+\item{ordering}{Prior to fitting any functions, should the data be reordered by the x-axis variable or by time? Default is to use the current x-axis variable and use the time variable to break any ties.}
 
-\item{bp}{Is this algorithm being used to find vt1 or vt2?}
+\item{alpha_linearity}{Significance value to determine if a piecewise model explains significantly reduces the residual sums of squares more than a simpler model.}
 
 \item{pos_change}{Do you expect the change in slope to be positive (default) or negative? If a two-line regression explains significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate.}
 
-\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
+\item{pos_slope_after_bp}{Should the slope after the breakpoint be positive? Default is `TRUE`. This catches cases when the percent change in slope is positive, but the second slope is still negative. Change to `FALSE` when PetCO2 is the y-axis variable.}
 }
 \value{
 A list including slice of the original data frame at the threshold index with new columns `algorithm`, `determinant_bp`, `pct_slope_change`, `f_stat`, and `p_val_f.` The list also includes the fitted values, the left and right sides of the piecewise regression, and a simple linear regression.

--- a/man/jm.Rd
+++ b/man/jm.Rd
@@ -9,6 +9,7 @@ jm(
   .x,
   .y,
   bp,
+  ...,
   vo2 = "vo2",
   vco2 = "vco2",
   ve = "ve",
@@ -17,7 +18,8 @@ jm(
   front_trim_vt1 = 60,
   front_trim_vt2 = 60,
   pos_change = TRUE,
-  ...
+  pos_slope_after_bp = TRUE,
+  ordering = c("by_x", "time")
 )
 }
 \arguments{
@@ -28,6 +30,8 @@ jm(
 \item{.y}{the y-axis variable.}
 
 \item{bp}{Is this algorithm being used to find vt1 or vt2?}
+
+\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
 
 \item{vo2}{The name of the vo2 column in \code{.data}}
 
@@ -45,7 +49,9 @@ jm(
 
 \item{pos_change}{Do you expect the change in slope to be positive (default) or negative? If a two-line regression explains significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate.}
 
-\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
+\item{pos_slope_after_bp}{Should the slope after the breakpoint be positive? Default is `TRUE`. This catches cases when the percent change in slope is positive, but the second slope is still negative. Change to `FALSE` when PetCO2 is the y-axis variable.}
+
+\item{ordering}{Prior to fitting any functions, should the data be reordered by the x-axis variable or by time? Default is to use the current x-axis variable and use the time variable to break any ties.}
 }
 \value{
 A list including slice of the original data frame at the threshold index with new columns `algorithm`, `determinant_bp`, `pct_slope_change`, `f_stat`, and `p_val_f.` The list also includes the fitted values, the left and right sides of the piecewise regression, and a simple linear regression.

--- a/man/orr.Rd
+++ b/man/orr.Rd
@@ -9,15 +9,17 @@ orr(
   .x,
   .y,
   bp,
+  ...,
   vo2 = "vo2",
   vco2 = "vco2",
   ve = "ve",
   time = "time",
+  ordering = c("by_x", "time"),
   alpha_linearity = 0.05,
   front_trim_vt1 = 60,
   front_trim_vt2 = 60,
   pos_change = TRUE,
-  ...
+  pos_slope_after_bp = TRUE
 )
 }
 \arguments{
@@ -29,6 +31,8 @@ orr(
 
 \item{bp}{Is this algorithm being used to find vt1 or vt2?}
 
+\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
+
 \item{vo2}{The name of the vo2 column in \code{.data}}
 
 \item{vco2}{The name of the vco2 column in \code{.data}}
@@ -36,6 +40,8 @@ orr(
 \item{ve}{The name of the ve column in \code{.data}}
 
 \item{time}{The name of the time column in \code{.data}}
+
+\item{ordering}{Prior to fitting any functions, should the data be reordered by the x-axis variable or by time? Default is to use the current x-axis variable and use the time variable to break any ties.}
 
 \item{alpha_linearity}{Significance value to determine if a piecewise model explains significantly reduces the residual sums of squares more than a simpler model.}
 
@@ -45,7 +51,7 @@ orr(
 
 \item{pos_change}{Do you expect the change in slope to be positive (default) or negative? If a two-line regression explains significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate.}
 
-\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
+\item{pos_slope_after_bp}{Should the slope after the breakpoint be positive? Default is `TRUE`. This catches cases when the percent change in slope is positive, but the second slope is still negative. Change to `FALSE` when PetCO2 is the y-axis variable.}
 }
 \value{
 A list including slice of the original data frame at the threshold index with new columns `algorithm`, `determinant_bp`, `pct_slope_change`, `f_stat`, and `p_val_f.` The list also includes the fitted values, the left and right sides of the piecewise regression, and a simple linear regression.

--- a/man/spline_bp.Rd
+++ b/man/spline_bp.Rd
@@ -18,6 +18,7 @@ spline_bp(
   front_trim_vt2 = 60,
   alpha_linearity = 0.05,
   pos_change = TRUE,
+  ordering = c("by_x", "time"),
   ...
 )
 }
@@ -42,7 +43,8 @@ spline_bp(
 
 \item{front_trim_vt1}{How much data (in seconds) to remove from the beginning of the test prior to fitting any regressions. The original V-slope paper suggests 1 minute.}
 
-\item{front_trim_vt2}{How much data (in seconds) to remove from the beginning of the test prior to fitting any regressions. The original V-slope paper suggests 1 minute.}
+\item{front_trim_vt2}{How much data (in seconds) to remove from the beginning of the test prior to fitting any regressions. The original V-slope paper suggests 1 minute.
+#' @param ordering Prior to fitting any functions, should the data be reordered by the x-axis variable or by time? Default is to use the current x-axis variable and use the time variable to break any ties.}
 
 \item{alpha_linearity}{Significance value to determine if a piecewise model explains significantly reduces the residual sums of squares more than a simpler model.}
 

--- a/man/spline_bp.Rd
+++ b/man/spline_bp.Rd
@@ -18,6 +18,7 @@ spline_bp(
   front_trim_vt2 = 60,
   alpha_linearity = 0.05,
   pos_change = TRUE,
+  pos_slope_after_bp = TRUE,
   ordering = c("by_x", "time"),
   ...
 )
@@ -43,12 +44,15 @@ spline_bp(
 
 \item{front_trim_vt1}{How much data (in seconds) to remove from the beginning of the test prior to fitting any regressions. The original V-slope paper suggests 1 minute.}
 
-\item{front_trim_vt2}{How much data (in seconds) to remove from the beginning of the test prior to fitting any regressions. The original V-slope paper suggests 1 minute.
-#' @param ordering Prior to fitting any functions, should the data be reordered by the x-axis variable or by time? Default is to use the current x-axis variable and use the time variable to break any ties.}
+\item{front_trim_vt2}{How much data (in seconds) to remove from the beginning of the test prior to fitting any regressions. The original V-slope paper suggests 1 minute.}
 
 \item{alpha_linearity}{Significance value to determine if a piecewise model explains significantly reduces the residual sums of squares more than a simpler model.}
 
 \item{pos_change}{Do you expect the change in slope to be positive (default) or negative? If a two-line regression explains significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate.}
+
+\item{pos_slope_after_bp}{Should the slope after the breakpoint be positive? Default is `TRUE`. This catches cases when the percent change in slope is positive, but the second slope is still negative. Change to `FALSE` when PetCO2 is the y-axis variable.}
+
+\item{ordering}{Prior to fitting any functions, should the data be reordered by the x-axis variable or by time? Default is to use the current x-axis variable and use the time variable to break any ties.}
 
 \item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
 }

--- a/man/v_slope.Rd
+++ b/man/v_slope.Rd
@@ -9,6 +9,7 @@ v_slope(
   .x,
   .y,
   bp,
+  ...,
   vo2 = "vo2",
   vco2 = "vco2",
   ve = "ve",
@@ -20,7 +21,8 @@ v_slope(
   front_trim_vt2 = 60,
   alpha_linearity = 0.05,
   pos_change = TRUE,
-  ...
+  pos_slope_after_bp = TRUE,
+  ordering = c("by_x", "time")
 )
 }
 \arguments{
@@ -31,6 +33,8 @@ v_slope(
 \item{.y}{the y-axis variable.}
 
 \item{bp}{Is this algorithm being used to find vt1 or vt2?}
+
+\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
 
 \item{vo2}{The name of the vo2 column in \code{.data}}
 
@@ -54,13 +58,15 @@ v_slope(
 
 \item{pos_change}{Do you expect the change in slope to be positive (default) or negative? If a two-line regression explains significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate.}
 
-\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
+\item{pos_slope_after_bp}{Should the slope after the breakpoint be positive? Default is `TRUE`. This catches cases when the percent change in slope is positive, but the second slope is still negative. Change to `FALSE` when PetCO2 is the y-axis variable.}
+
+\item{ordering}{Prior to fitting any functions, should the data be reordered by the x-axis variable or by time? Default is to use the current x-axis variable and use the time variable to break any ties.}
 }
 \value{
 A list including slice of the original data frame at the threshold index with new columns `algorithm`, `determinant_bp`, `pct_slope_change`, `f_stat`, and `p_val_f.` The list also includes the fitted values, the left and right sides of the piecewise regression, and a simple linear regression.
 }
 \description{
-V-slope uses the v-slope \emph{algorithm} to find a breakpoint. Note, the v-slope algorithm is different from the v-slope \emph{method} as a whole because the latter also includes a specific set of data processing steps (see reference). In order to use the v-slope algorithm as originally described by Beaver et al. (1986), pass \code{"v-slope"} to the \code{method} argument in the \code{breakpoint} function. Without indicating the \code{method} as \code{"v-slope"}, the function returns the breakpoint associated with ratio of the highest distance between the single regression line to the intersection point of the two regression lines, to the mean square error of the single regression line. This can sometimes lead to odd behavior and it is therefore generally recommended to specify \code{"v-slope"} in the \code{method} argument of \code{breakpoint} when using this function. See the Warnings and Details sections for details.
+V-slope uses the v-slope \emph{algorithm} to find a breakpoint. Note, the v-slope algorithm is different from the v-slope \emph{method} as a whole because the latter also includes a specific set of data processing steps (Beaver et al., 1986). In order to use the v-slope algorithm as originally described by Beaver et al. (1986), pass \code{"v-slope"} to the \code{method} argument in the \code{breakpoint} function. Without indicating the \code{method} as \code{"v-slope"}, the function returns the breakpoint associated with ratio of the highest distance between the single regression line to the intersection point of the two regression lines, to the mean square error of the piecewise regression lines. This can sometimes lead to odd behavior and it is therefore generally recommended to specify \code{"v-slope"} in the \code{method} argument of \code{breakpoint} when using this function. See the Warnings and Details sections for details.
 }
 \details{
 If the \code{method} argument is set to \code{"v-slope"}, the function enters a while loop to satisfy the quality control criteria (see Warnings section for details). Otherwise, the function returns the breakpoint as described the initial description.

--- a/man/wb_rc.Rd
+++ b/man/wb_rc.Rd
@@ -9,6 +9,7 @@ wb_rc(
   .x,
   .y,
   bp,
+  ...,
   vo2 = "vo2",
   vco2 = "vco2",
   ve = "ve",
@@ -17,8 +18,7 @@ wb_rc(
   front_trim_vt1 = 60,
   front_trim_vt2 = 60,
   pos_change = TRUE,
-  min_pct_change = 0.15,
-  ...
+  min_pct_change = 0.15
 )
 }
 \arguments{
@@ -29,6 +29,8 @@ wb_rc(
 \item{.y}{the y-axis variable.}
 
 \item{bp}{Is this algorithm being used to find vt1 or vt2?}
+
+\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
 
 \item{vo2}{The name of the vo2 column in \code{.data}}
 
@@ -47,8 +49,6 @@ wb_rc(
 \item{pos_change}{Do you expect the change in slope to be positive (default) or negative? If a two-line regression explains significantly reduces the sum square error but the change in slope does not match the expected underlying physiology, the breakpoint will be classified as indeterminate.}
 
 \item{min_pct_change}{The original V-slope method (Beaver et al., 1986) considers the respiratory compensation point as determinant "if the change in slope"...between the left and right regressions..."is greater than a preselected amount (15\% of the initial slope)." See details for the specific WinBreak implementation.}
-
-\item{...}{Dot dot dot mostly allows this function to work properly if breakpoint() passes arguments that is not strictly needed by this function.}
 }
 \value{
 A list including slice of the original data frame at the threshold index with new columns `algorithm`, `determinant_bp`, `pct_slope_change`, `f_stat`, and `p_val_f.` The list also includes the fitted values, the left and right sides of the piecewise regression, and a simple linear regression.


### PR DESCRIPTION
I would generally advise against it, but some older programs only allow data to be split by time rather than by the current x-axis variable. I've added that option to breakpoint() and to each individual breakpoint function.

Also, there were some corner cases where the breakpoint was considered determinant because there was a positive percent change in slope, but it went from a negative number to a less negative number. I've included an argument for that logic and a helper function to determine the breakpoint.